### PR TITLE
snow: Fix import statements after collection migration

### DIFF
--- a/plugins/modules/snow_record.py
+++ b/plugins/modules/snow_record.py
@@ -153,7 +153,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes, to_native
-from ansible_collections.n3pjk.servicenow.plugins.module_utils.service_now import ServiceNowClient
+from ansible_collections.servicenow.servicenow.plugins.module_utils.service_now import ServiceNowClient
 
 try:
     # This is being handled by ServiceNowClient

--- a/plugins/modules/snow_record_find.py
+++ b/plugins/modules/snow_record_find.py
@@ -122,7 +122,7 @@ record:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.n3pjk.servicenow.plugins.module_utils.service_now import ServiceNowClient
+from ansible_collections.servicenow.servicenow.plugins.module_utils.service_now import ServiceNowClient
 from ansible.module_utils._text import to_native
 
 try:


### PR DESCRIPTION
Correct namespace for servicenow module is 'servicenow.servicenow'

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>