### PR TITLE
Enhanced Inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 *.tar.gz
+__pycache__
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
-# Service Now
-The Service Now modules previously packaged as part of Ansible, now in a Collection distributed via Ansible Galaxy.
+# Ansible Collection for ServiceNow
+This collection provides a series of Ansible modules, roles, and plugins for interacting with [ServiceNow](https://servicenow.com)
+
+## Requirements
+ - ansible version >= 2.9
+ - pysnow
+ - netaddr
+
+## Installation
+
+To install Azure collection hosted in Galaxy:
+
+```bash
+ansible-galaxy collection install servicenow.servicenow
+```
+
+To upgrade to the latest version of Azure collection:
+
+```bash
+ansible-galaxy collection install servicenow.servicenow --force
+```
+## Usage
+
+### Playbooks
+
+To use a module from the ServiceNow collection, please reference the fill namespace, collection name, and module name that you want to use:
+
+```yaml
+---
+- name: Using ServiceNow Collection
+  hosts: localhost
+  gather_facts: no
+  
+  tasks:
+  - name: Create an incident
+    servicenow.servicenow.snow_record:
+      username: ansible_test
+      password: my_password
+      instance: dev99999
+      state: present
+      data:
+        short_description: "This is a test incident opened by Ansible"
+        severity: 3
+        priority: 2
+```
+
+Or you can add full namespace and collection name in the `collections` section:
+
+```yaml
+---
+- name: Using ServiceNow Collection
+  hosts: localhost
+  gather_facts: no
+  collections:
+    - servicenow.servicenow
+  
+  tasks:
+  - name: Create an incident
+    snow_record:
+      username: ansible_test
+      password: my_password
+      instance: dev99999
+      state: present
+      data:
+        short_description: "This is a test incident opened by Ansible"
+        severity: 3
+        priority: 2
+```
+
+### Roles
+
+For existing Ansible roles, please also reference the full namespace, collection name, and modules name which used in tasks instead of just modules name.
+
+## Resource Included
+
+### Modules
+- snow_record - Creates, deletes and updates a single record in ServiceNow.
+- snow_record_find - Gets multiple records from a specified table from ServiceNow based on a query dictionary.
+
+### Plugins
+-  now - ServiceNow Inventory Plugin
+
+## Contributing
+
+There are many ways in which you can participate in the project, for example:
+
+- Submit bugs and feature requests, and help us verify as they are checked in
+- Review source code changes
+- Review the documentation and make pull requests for anything from typos to new content
+
+Special thanks to Tim Rightnour (@garbled1) for the original version of ServiceNow modules in Ansible Core.

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -168,7 +168,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                                            'http': proxy,
                                            'https': proxy
                                        })
-                if response.status_code != 200:
+                if response.status_code == 400 and self.get_option('enhanced'):
+                    raise AnsibleError("http error (%s): %s. Have you installed the enhanced inventory update set on your instance?" %
+                                       (response.status_code, response.text))
+                elif response.status_code != 200:
                     raise AnsibleError("http error (%s): %s" %
                                        (response.status_code, response.text))
                 results += response.json()['result']

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 DOCUMENTATION = r'''
-    name: now
+    name: servicenow.servicenow.now
     plugin_type: inventory
     author:
       - Will Tome (@willtome)
@@ -43,12 +43,11 @@ DOCUMENTATION = r'''
         fields:
             description: Comma seperated string providing additional table columns to add as host vars to each inventory host.
             type: list
-            default: 'ip_address,fqdn,host_name,sys_class_name'
-
+            default: 'ip_address,fqdn,host_name,sys_class_name,name'
         selection_order:
             description: Comma seperated string providing ability to define selection preference order.
             type: list
-            default: 'ip_address,fqdn,host_name'
+            default: 'ip_address,fqdn,host_name,name'
         filter_results:
             description: Filter results with sysparm_query encoded query string syntax. Complete list of operators available for filters and queries.
             type: string
@@ -57,10 +56,19 @@ DOCUMENTATION = r'''
             description: Proxy server to use for requests to ServiceNow.
             type: string
             default: ''
+        enhanced:
+            description: enable enhanced inventory which provides relationship information from CMDB. Requires installation of Update Set.
+            type: bool
+            default: False
+        enhanced_groups:
+            description: enable enhanced groups from CMDB relationships. Only used if enhanced is enabled. 
+            type: bool
+            default: True
+
 '''
 
 EXAMPLES = r'''
-plugin: now
+plugin: servicenow.servicenow.now
 instance: demo.service-now.com
 username: admin
 password: password
@@ -101,8 +109,9 @@ keyed_groups:
     prefix: 'tag'
 '''
 
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
 from ansible.errors import AnsibleError, AnsibleParserError
+import netaddr
 try:
     import requests
     HAS_REQUESTS = True
@@ -114,6 +123,15 @@ import sys
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     NAME = 'servicenow.servicenow.now'
+
+    def verify_file(self, path):
+         valid = False
+         if super(InventoryModule, self).verify_file(path):
+             if path.endswith(('now.yaml', 'now.yml')):
+                 valid = True
+             else:
+                 self.display.vvv('Skipping due to inventory source not ending in "now.yaml" nor "now.yml"')
+         return valid
 
     def invoke(self, verb, path, data):
         auth = requests.auth.HTTPBasicAuth(self.get_option('username'),
@@ -184,9 +202,19 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         options = "?sysparm_exclude_reference_link=true&sysparm_display_value=true"
 
-        path = '/api/now/table/' + table + options + \
-            "&sysparm_fields=" + ','.join(fields) + \
-            "&sysparm_query=" + filter_results
+        enhanced = self.get_option('enhanced')
+        enhanced_groups = False
+
+        if enhanced:
+            path = '/api/snc/ansible_inventory' + options + \
+                "&sysparm_fields=" + ','.join(fields) + \
+                "&sysparm_query=" + filter_results + \
+                "&table=" + table
+            enhanced_groups = self.get_option('enhanced_groups')
+        else:
+            path = '/api/now/table/' + table + options + \
+                "&sysparm_fields=" + ','.join(fields) + \
+                "&sysparm_query=" + filter_results
 
         content = self.invoke('GET', path, None)
         strict = self.get_option('strict')
@@ -195,6 +223,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             target = None
 
+            #select name for host
             for k in selection:
                 if k in record:
                     if record[k] != '':
@@ -205,15 +234,43 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if target is None:
                 continue
 
-            host_name = self.inventory.add_host(target)
+            # add host to inventory
+            if netaddr.valid_ipv4(target) or netaddr.valid_ipv6(target):
+              host_name = self.inventory.add_host(target)
+            else:
+              host_name = self.inventory.add_host(to_safe_group_name(target))
 
+            # set variables for host
             for k in record.keys():
                 self.inventory.set_variable(host_name, 'sn_%s' % k, record[k])
+
+            # add relationship based groups
+            if enhanced and enhanced_groups:
+                for item in record['child_relationships']:
+                    ci = to_safe_group_name(item['ci'])
+                    ci_rel_type = to_safe_group_name(item['ci_rel_type'].split('__')[0])
+                    ci_type = to_safe_group_name(item['ci_type'])
+    
+                    if ci != '' and ci_rel_type != '' and ci_type != '':
+                        child_group = "%s_%s" % (ci, ci_rel_type)
+                        self.inventory.add_group(child_group)
+                        self.inventory.add_child(child_group, host_name)
+                
+                for item in record['parent_relationships']:
+                    ci = to_safe_group_name(item['ci'])
+                    ci_rel_type = to_safe_group_name(item['ci_rel_type'].split('__')[-1])
+                    ci_type = to_safe_group_name(item['ci_type'])
+    
+                    if ci != '' and ci_rel_type != '' and ci_type != '':
+                        child_group = "%s_%s" % (ci, ci_rel_type)
+                        self.inventory.add_group(child_group)
+                        self.inventory.add_child(child_group, host_name)
 
             self._set_composite_vars(
                 self.get_option('compose'),
                 self.inventory.get_host(host_name).get_vars(), host_name,
                 strict)
+
             self._add_host_to_composed_groups(self.get_option('groups'),
                                               dict(), host_name, strict)
             self._add_host_to_keyed_groups(self.get_option('keyed_groups'),

--- a/tests/enhanced.now.yml
+++ b/tests/enhanced.now.yml
@@ -1,0 +1,10 @@
+---
+plugin: servicenow.servicenow.now
+instance: dev93775.service-now.com
+username: admin
+password: knTVFcRlD6d9
+selection_order: name
+enhanced: True
+keyed_groups:
+    - key: sn_sys_class_name
+      prefix: sn

--- a/tests/enhanced.now.yml
+++ b/tests/enhanced.now.yml
@@ -5,6 +5,6 @@ username: admin
 password: knTVFcRlD6d9
 selection_order: name
 enhanced: True
-keyed_groups:
-    - key: sn_sys_class_name
-      prefix: sn
+#keyed_groups:
+#    - key: sn_sys_class_name
+#      prefix: sn

--- a/tests/network.enhanced.now.yml
+++ b/tests/network.enhanced.now.yml
@@ -2,6 +2,7 @@
 plugin: servicenow.servicenow.now
 instance: dev93775.service-now.com
 username: admin
-password: knTVFcRlD6d9
+password: le4MnTLd3bCK
 table: cmdb_ci_netgear
+selection_order: name
 enhanced: True

--- a/tests/network.enhanced.now.yml
+++ b/tests/network.enhanced.now.yml
@@ -1,0 +1,7 @@
+---
+plugin: servicenow.servicenow.now
+instance: dev93775.service-now.com
+username: admin
+password: knTVFcRlD6d9
+table: cmdb_ci_netgear
+enhanced: True

--- a/tests/now.yml
+++ b/tests/now.yml
@@ -1,0 +1,25 @@
+---
+plugin: servicenow.servicenow.now
+instance: dev93775.service-now.com
+username: admin
+password: le4MnTLd3bCK
+selection_order: name
+fields:
+  - os
+  - ip_address
+  - fqdn
+  - host_name
+  - sys_class_name
+  - name
+  - disk_space
+compose:
+  os_class: sn_os.split(' ')[0]
+groups:
+  large: (sn_disk_space | int) > 100
+  SAP: inventory_hostname.startswith('SAP')
+keyed_groups:
+    - key: sn_sys_class_name
+      prefix: sn
+    - key: os_class
+      prefix: ''
+      separator: ''

--- a/update_sets/README.md
+++ b/update_sets/README.md
@@ -1,0 +1,5 @@
+# Update Sets for Ansible Integration
+This directory provides update sets that may be required to unlock functionality in ServiceNow.
+
+## ansible_enhanced_inventory
+This update set installs a scripted REST API into your ServiceNow instance. This is required for the `enhanced` parameter in the `now` inventory plugin to function. "enhanced" provides CI relationship data to the plugin so that it can build additional groups in your inventory.

--- a/update_sets/ansible_enhanced_inventory.xml
+++ b/update_sets/ansible_enhanced_inventory.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?><unload unload_date="2020-01-30 23:28:32">
+<sys_remote_update_set action="INSERT_OR_UPDATE">
+<application display_value="Global">global</application>
+<application_name>Global</application_name>
+<application_scope>global</application_scope>
+<application_version/>
+<collisions/>
+<commit_date/>
+<deleted/>
+<description/>
+<inserted/>
+<name>Ansible_Inventory</name>
+<origin_sys_id/>
+<parent display_value=""/>
+<release_date/>
+<remote_base_update_set display_value=""/>
+<remote_parent_id/>
+<remote_sys_id>d9552962db66481085449eb5db961931</remote_sys_id>
+<state>loaded</state>
+<summary/>
+<sys_class_name>sys_remote_update_set</sys_class_name>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2020-01-30 23:28:31</sys_created_on>
+<sys_id>674a39afdb220010081a3ec8f496197d</sys_id>
+<sys_mod_count>0</sys_mod_count>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2020-01-30 23:28:31</sys_updated_on>
+<update_set display_value=""/>
+<update_source display_value=""/>
+<updated/>
+</sys_remote_update_set>
+<sys_update_xml action="INSERT_OR_UPDATE">
+<action>INSERT_OR_UPDATE</action>
+<application display_value="Global">global</application>
+<category>customer</category>
+<comments/>
+<name>sys_ws_query_parameter_map_9e0a692adb66481085449eb5db961931</name>
+<payload><![CDATA[<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter_map"><sys_ws_query_parameter_map action="INSERT_OR_UPDATE"><sys_class_name>sys_ws_query_parameter_map</sys_class_name><sys_created_by>admin</sys_created_by><sys_created_on>2020-01-27 19:44:45</sys_created_on><sys_customer_update>false</sys_customer_update><sys_id>9e0a692adb66481085449eb5db961931</sys_id><sys_mod_count>0</sys_mod_count><sys_name>3f2a692adb66481085449eb5db9619e2</sys_name><sys_package display_value="Global" source="global">global</sys_package><sys_policy/><sys_replace_on_upgrade>false</sys_replace_on_upgrade><sys_scope display_value="Global">global</sys_scope><sys_update_name>sys_ws_query_parameter_map_9e0a692adb66481085449eb5db961931</sys_update_name><sys_updated_by>admin</sys_updated_by><sys_updated_on>2020-01-27 19:44:45</sys_updated_on><web_service_operation display_value="Ansible Inventory">20b521a2db66481085449eb5db96190f</web_service_operation><web_service_query_parameter display_value="sysparm_fields">3f2a692adb66481085449eb5db9619e2</web_service_query_parameter></sys_ws_query_parameter_map></record_update>]]></payload>
+<payload_hash>1820109461</payload_hash>
+<remote_update_set display_value="Ansible_Inventory">674a39afdb220010081a3ec8f496197d</remote_update_set>
+<replace_on_upgrade>false</replace_on_upgrade>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2020-01-30 23:28:31</sys_created_on>
+<sys_id>2b4a39afdb220010081a3ec8f496197e</sys_id>
+<sys_mod_count>0</sys_mod_count>
+<sys_recorded_at>16fe888ecab0000001</sys_recorded_at>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2020-01-30 23:28:31</sys_updated_on>
+<table/>
+<target_name>3f2a692adb66481085449eb5db9619e2</target_name>
+<type>Scripted REST Query Parameter Associatio</type>
+<update_domain>global</update_domain>
+<update_guid>645a2d2a0d6648100f79ab3c3f9ebb43</update_guid>
+<update_guid_history>645a2d2a0d6648100f79ab3c3f9ebb43:1820109461</update_guid_history>
+<update_set display_value=""/>
+<view/>
+</sys_update_xml>
+<sys_update_xml action="INSERT_OR_UPDATE">
+<action>INSERT_OR_UPDATE</action>
+<application display_value="Global">global</application>
+<category>customer</category>
+<comments/>
+<name>sys_ws_query_parameter_3f2a692adb66481085449eb5db9619e2</name>
+<payload><![CDATA[<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_query_parameter"><sys_ws_query_parameter action="INSERT_OR_UPDATE"><example_value>fqdn,host_name,ip_address,name,sys_class_name</example_value><name>sysparm_fields</name><required>true</required><short_description>field paramters for searching cmdb_ci_server</short_description><sys_class_name>sys_ws_query_parameter</sys_class_name><sys_created_by>admin</sys_created_by><sys_created_on>2020-01-27 19:44:42</sys_created_on><sys_customer_update>false</sys_customer_update><sys_id>3f2a692adb66481085449eb5db9619e2</sys_id><sys_mod_count>1</sys_mod_count><sys_name>sysparm_fields</sys_name><sys_package display_value="Global" source="global">global</sys_package><sys_policy/><sys_replace_on_upgrade>false</sys_replace_on_upgrade><sys_scope display_value="Global">global</sys_scope><sys_update_name>sys_ws_query_parameter_3f2a692adb66481085449eb5db9619e2</sys_update_name><sys_updated_by>admin</sys_updated_by><sys_updated_on>2020-01-27 19:44:54</sys_updated_on><web_service_definition display_value="Ansible Inventory">8e95e962db66481085449eb5db961952</web_service_definition></sys_ws_query_parameter></record_update>]]></payload>
+<payload_hash>735828070</payload_hash>
+<remote_update_set display_value="Ansible_Inventory">674a39afdb220010081a3ec8f496197d</remote_update_set>
+<replace_on_upgrade>false</replace_on_upgrade>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2020-01-30 23:28:31</sys_created_on>
+<sys_id>674a39afdb220010081a3ec8f496197e</sys_id>
+<sys_mod_count>0</sys_mod_count>
+<sys_recorded_at>16fe8890fae0000001</sys_recorded_at>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2020-01-30 23:28:31</sys_updated_on>
+<table/>
+<target_name>sysparm_fields</target_name>
+<type>Scripted REST Query Parameter</type>
+<update_domain>global</update_domain>
+<update_guid>625aed2ab966481080dc3bfae30dadbd</update_guid>
+<update_guid_history>625aed2ab966481080dc3bfae30dadbd:735828070,7f4ae92a586648109b769b2578bf6652:-407882821</update_guid_history>
+<update_set display_value=""/>
+<view/>
+</sys_update_xml>
+<sys_update_xml action="INSERT_OR_UPDATE">
+<action>INSERT_OR_UPDATE</action>
+<application display_value="Global">global</application>
+<category>customer</category>
+<comments/>
+<name>sys_ws_operation_20b521a2db66481085449eb5db96190f</name>
+<payload>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;record_update table="sys_ws_operation"&gt;&lt;sys_ws_operation action="INSERT_OR_UPDATE"&gt;&lt;active&gt;true&lt;/active&gt;&lt;consumes&gt;application/json,application/xml,text/xml&lt;/consumes&gt;&lt;consumes_customized&gt;false&lt;/consumes_customized&gt;&lt;default_operation_uri/&gt;&lt;enforce_acl&gt;cf9d01d3e73003009d6247e603f6a990&lt;/enforce_acl&gt;&lt;http_method&gt;GET&lt;/http_method&gt;&lt;name&gt;Ansible Inventory&lt;/name&gt;&lt;operation_script&gt;&lt;![CDATA[(function process( /*RESTAPIRequest*/ request, /*RESTAPIResponse*/ response) {
+
+    function getRelatedSubCI(sys_id, target) {
+
+        var gp = [];
+        var a = sys_id; //current.cmdb_ci;
+
+        //cmdb_rel_ci has the relationship to child CIs
+        var grp = new GlideRecord('cmdb_rel_ci');
+        grp.addQuery(target, a);
+        grp.query();
+
+        var x = 0;
+        while (grp.next()) {
+            gp[x] = {};
+            target == 'parent' ? gp[x].ci_type = grp.child.sys_class_name.getDisplayValue() : gp[x].ci_type = grp.parent.sys_class_name.getDisplayValue();
+            gp[x].ci_rel_type = grp.type.getDisplayValue().replace(/\s|:/g, "_");
+            target == 'parent' ? gp[x].ci = grp.child.name : gp[x].ci = grp.parent.name;
+            x++;
+        }
+
+        return gp;
+    }
+
+    if (!request.queryParams.sysparm_fields) {
+        response.setStatus(400);
+        response.setContentType('application/json');
+        response.setError(new sn_ws_err.BadRequestError("no sysparm_fields query param"));
+    } else if (!request.queryParams.table) {
+        response.setStatus(400);
+        response.setContentType('application/json');
+        response.setError(new sn_ws_err.BadRequestError("no table specified"));
+    } else {
+
+        var queryString = "sysparm_exclude_reference_link=false&amp;sysparm_display_value=true&amp;sysparm_fields=" + request.queryParams.sysparm_fields + "&amp;sysparm_query";
+
+        var table = request.queryParams.table;
+		
+        if (!/^cmdb_ci_/.test(table)) {
+            response.setStatus(400);
+            response.setContentType('application/json');
+            response.setError(new sn_ws_err.BadRequestError("table must be a child of cmdb_ci"));
+        } else if (!gs.tableExists(table)) {
+			response.setStatus(400);
+            response.setContentType('application/json');
+            response.setError(new sn_ws_err.BadRequestError("specified table "+table+" does not exist"));
+		} else {
+
+            var regexp = /^.+sysparm_fields\=(.*)\&amp;\w*/;
+            var fields = (queryString.match(regexp))[1].split(',');
+
+            var gr = new GlideRecord(table);
+            gr.addEncodedQuery(queryString);
+            gr.query();
+
+            var results = {
+                'result': []
+            };
+            var i = 0;
+            var parent = {};
+            var child = {};
+
+            while (gr.next()) {
+
+                parent = getRelatedSubCI(gr.sys_id, 'parent');
+                child = getRelatedSubCI(gr.sys_id, 'child');
+                results['result'][i] = {
+                    //'parent': parent.ci,
+                    'parent_relationships': parent,
+                    //'child': child.ci,
+                    'child_relationships': child
+                };
+                for (y in fields) {
+                    results['result'][i][fields[y]] = gr.getDisplayValue(fields[y]);
+                }
+                i++;
+            }
+            response.setContentType('application/json');
+            response.setStatus(200);
+            response.setBody(results.result);
+        }
+    }
+
+})(request, response);]]&gt;&lt;/operation_script&gt;&lt;operation_uri&gt;/api/snc/ansible_inventory&lt;/operation_uri&gt;&lt;produces&gt;application/json,application/xml,text/xml&lt;/produces&gt;&lt;produces_customized&gt;false&lt;/produces_customized&gt;&lt;relative_path&gt;/&lt;/relative_path&gt;&lt;request_example/&gt;&lt;requires_acl_authorization&gt;true&lt;/requires_acl_authorization&gt;&lt;requires_authentication&gt;true&lt;/requires_authentication&gt;&lt;requires_snc_internal_role&gt;false&lt;/requires_snc_internal_role&gt;&lt;short_description/&gt;&lt;sys_class_name&gt;sys_ws_operation&lt;/sys_class_name&gt;&lt;sys_created_by&gt;admin&lt;/sys_created_by&gt;&lt;sys_created_on&gt;2020-01-27 19:24:55&lt;/sys_created_on&gt;&lt;sys_customer_update&gt;false&lt;/sys_customer_update&gt;&lt;sys_id&gt;20b521a2db66481085449eb5db96190f&lt;/sys_id&gt;&lt;sys_mod_count&gt;50&lt;/sys_mod_count&gt;&lt;sys_name&gt;Ansible Inventory&lt;/sys_name&gt;&lt;sys_package display_value="Global" source="global"&gt;global&lt;/sys_package&gt;&lt;sys_policy/&gt;&lt;sys_replace_on_upgrade&gt;false&lt;/sys_replace_on_upgrade&gt;&lt;sys_scope display_value="Global"&gt;global&lt;/sys_scope&gt;&lt;sys_update_name&gt;sys_ws_operation_20b521a2db66481085449eb5db96190f&lt;/sys_update_name&gt;&lt;sys_updated_by&gt;admin&lt;/sys_updated_by&gt;&lt;sys_updated_on&gt;2020-01-27 21:15:10&lt;/sys_updated_on&gt;&lt;web_service_definition display_value="Ansible Inventory"&gt;8e95e962db66481085449eb5db961952&lt;/web_service_definition&gt;&lt;web_service_version/&gt;&lt;/sys_ws_operation&gt;&lt;/record_update&gt;</payload>
+<payload_hash>1074422118</payload_hash>
+<remote_update_set display_value="Ansible_Inventory">674a39afdb220010081a3ec8f496197d</remote_update_set>
+<replace_on_upgrade>false</replace_on_upgrade>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2020-01-30 23:28:31</sys_created_on>
+<sys_id>a34a39afdb220010081a3ec8f496197e</sys_id>
+<sys_mod_count>0</sys_mod_count>
+<sys_recorded_at>16fe8dbb49b0000001</sys_recorded_at>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2020-01-30 23:28:31</sys_updated_on>
+<table/>
+<target_name>Ansible Inventory</target_name>
+<type>Scripted REST Resource</type>
+<update_domain>global</update_domain>
+<update_guid>0d0f3d669ae648105dfd0d683c641e24</update_guid>
+<update_guid_history>0d0f3d669ae648105dfd0d683c641e24:1074422118,856e3d66dae64810343768747a3e321f:1730035206,2e0d7da23fe64810af6f7cfc7e18ad32:-1757677024,664cb5a2dae648105756166f01c41b01:-725853184,4cfbbd6236e648102bad37a1a8234fc1:-208273856,3f6b75ee3fa64810dd4596b8a05625c5:1376315424,955a75ee01a648103b53906e8d3dce6d:430933392,4ef975eee6a648106c3381093f8f6068:1312994583,6fa979aebea6481056a80d7f5a93c575:1636415031,9b7935ae99a6481014c1a8db5451bf1e:914602057,6149f1ae05a64810f588ce90d381f8c4:861040761,47c8b16ecaa64810937cf992b8c7dbef:1332608858,45a8392ec7a64810a79053c31d076568:-1494029102,dd78392e7ca64810ec844c995635c762:542268540,c248392e63a64810ac8ac28574078c38:1768105004,fcd7b92ab3a64810ac2f06ca7ed15758:-528303117,7cb6352a46a648107e490d8685595ae8:75471988,da75752a62a64810a34bc5a8b4651c54:-463417776,3745f9e2f7a648100ae5536a30222939:42335310,30d4f9e61fa6481014d6462867a6942c:-722896322,d3c1f9e222a6481086744cb783d9222f:-1652078180,d46179a2b4a64810396ce345c7af2ac2:-1206689548,0401fd62fda64810160cf8660d193849:-1445231948,d36071ee8866481015a991c63d34c1a6:1000577296,1f6ea56e8f6648102d6d1fcd343ff4e9:-1291387353,1c6d292ee8664810fd96d8dae3cdd0cf:339933249,cd3da12eec664810da6b553cff9071a1:-1931992928,478c69eaff664810c4cbb2f0c55d1efa:-468812462,dd7c69eafd66481043397b64c941abf4:2128744305,7e1ced6a9a664810a8cbdfc72b691bb2:1435735615,3afb6daabf6648103a1b25780cea4656:760621217,918b6daa3f664810efa2299b5daeb851:432563560,11eaed2a066648105911d7a91b242fcf:194023943,42ca216aa7664810be678c16dbedd44a:2132295303,ebf9292a99664810c589e3532d8e8765:-2137588737,02b925e6366648102df9ea72713185cc:-690959945,5839e5a6cc664810967bf75cc69a1215:1463531592,b78825a60366481034c8238c6802af7a:1073365151,526821a6aa664810fc96b9d7f4683c88:-1304589235,fc5861a65a664810a5b30ae1cf7dab34:1045386951,8948ed668f664810b3dbca0553c0e873:746752488,20186966986648107f2f6eb6ca1e1f9b:2119584903,6bd76526dd664810faffa12178ac1b94:1044137095,06a7ad26f86648109a504183943216ba:-1064086520,d28765267d664810cb3c474a040e4ccf:-1800063027,7f472126ac664810a5d32e6fbf80c047:1699569421,60172de27a664810c931e012b3ea1a4b:-856412088,30f62de2a16648107fd0ce8ca70da25f:-1714083000,1ce625a2b1664810fb3910e6405dbd41:311127871,1a2625a20866481066e4e95eebb61146:653669429,0ec525a24666481068bfb434beebdb04:924471465</update_guid_history>
+<update_set display_value=""/>
+<view/>
+</sys_update_xml>
+<sys_update_xml action="INSERT_OR_UPDATE">
+<action>INSERT_OR_UPDATE</action>
+<application display_value="Global">global</application>
+<category>customer</category>
+<comments/>
+<name>sys_ws_definition_8e95e962db66481085449eb5db961952</name>
+<payload><![CDATA[<?xml version="1.0" encoding="UTF-8"?><record_update table="sys_ws_definition"><sys_ws_definition action="INSERT_OR_UPDATE"><active>true</active><base_uri>/api/snc/ansible_inventory</base_uri><consumes>application/json,application/xml,text/xml</consumes><consumes_customized>false</consumes_customized><default_version>No active default version</default_version><doc_link/><enforce_acl>cf9d01d3e73003009d6247e603f6a990</enforce_acl><is_versioned>false</is_versioned><name>Ansible Inventory</name><namespace>snc</namespace><produces>application/json,application/xml,text/xml</produces><produces_customized>false</produces_customized><service_id>ansible_inventory</service_id><short_description/><sys_class_name>sys_ws_definition</sys_class_name><sys_created_by>admin</sys_created_by><sys_created_on>2020-01-27 19:24:14</sys_created_on><sys_customer_update>false</sys_customer_update><sys_id>8e95e962db66481085449eb5db961952</sys_id><sys_mod_count>1</sys_mod_count><sys_name>Ansible Inventory</sys_name><sys_package display_value="Global" source="global">global</sys_package><sys_policy/><sys_replace_on_upgrade>false</sys_replace_on_upgrade><sys_scope display_value="Global">global</sys_scope><sys_update_name>sys_ws_definition_8e95e962db66481085449eb5db961952</sys_update_name><sys_updated_by>admin</sys_updated_by><sys_updated_on>2020-01-27 19:24:29</sys_updated_on></sys_ws_definition></record_update>]]></payload>
+<payload_hash>740685616</payload_hash>
+<remote_update_set display_value="Ansible_Inventory">674a39afdb220010081a3ec8f496197d</remote_update_set>
+<replace_on_upgrade>false</replace_on_upgrade>
+<sys_created_by>admin</sys_created_by>
+<sys_created_on>2020-01-30 23:28:31</sys_created_on>
+<sys_id>eb4a39afdb220010081a3ec8f496197d</sys_id>
+<sys_mod_count>0</sys_mod_count>
+<sys_recorded_at>16fe8765f720000001</sys_recorded_at>
+<sys_updated_by>admin</sys_updated_by>
+<sys_updated_on>2020-01-30 23:28:31</sys_updated_on>
+<table/>
+<target_name>Ansible Inventory</target_name>
+<type>Scripted REST API</type>
+<update_domain>global</update_domain>
+<update_guid>2ba5ad625e664810987a1cee2ddbb698</update_guid>
+<update_guid_history>2ba5ad625e664810987a1cee2ddbb698:740685616,08a56d6278664810ea559a69b459e3d0:-1084756942</update_guid_history>
+<update_set display_value=""/>
+<view/>
+</sys_update_xml>
+</unload>


### PR DESCRIPTION
This PR adds "enhanced" functionality to the now inventory plugin. This requires a scripted REST API that can be installed using the provided update set. "enhanced" adds relationship information from the CMDB to the inventory as groups. Example:
```
@all:
  |--@Blackberry_Depends_on:
  |  |--INSIGHT_NY_03
  |--@Bond_Trading_Depends_on:
  |  |--lnux100
  |  |--unix201
  |--@Client_Services_Depends_on:
  |  |--lnux100
  |  |--lnux101
  |--@Java_Application_Server_FLX_Used_by:
  |  |--Webserver_FLX
  ...
```