### PR TITLE
Add Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ServiceNow Collection Changes
 
+## unreleased
+### Added
+  - CI status badge on README
+  - Add docs for inventory plugin
+
 ## [1.0.2]
 ### Added
   - CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unreleased
 ### Added
   - CI status badge on README
-  - Add docs for inventory plugin
+  - Add docs for inventory plugin and modules
 
 ## [1.0.2]
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ For existing Ansible roles, please also reference the full namespace, collection
 ## Resource Included
 
 ### Modules
-- snow_record - Creates, deletes and updates a single record in ServiceNow.
-- snow_record_find - Gets multiple records from a specified table from ServiceNow based on a query dictionary.
+- [snow_record](docs/snow_record.md) - Creates, deletes and updates a single record in ServiceNow.
+- [snow_record_find](docs/snow_record_find.md) - Gets multiple records from a specified table from ServiceNow based on a query dictionary.
 
 ### Plugins
 -  [now](docs/inventory.md) - ServiceNow Inventory Plugin

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For existing Ansible roles, please also reference the full namespace, collection
 - snow_record_find - Gets multiple records from a specified table from ServiceNow based on a query dictionary.
 
 ### Plugins
--  now - ServiceNow Inventory Plugin
+-  [now](docs/inventory.md) - ServiceNow Inventory Plugin
 
 ## Contributing
 

--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  gather_facts: no
+
+  tasks:
+    - set_fact:
+        docs: "{{ lookup('file', '../plugins/inventory/now.py') | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml}}"
+        examples: "{{ lookup('file', '../plugins/inventory/now.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
+
+    - template:
+        src: ./templates/inventory.md.j2
+        dest: ./inventory.md

--- a/docs/create_docs.yml
+++ b/docs/create_docs.yml
@@ -8,5 +8,21 @@
         examples: "{{ lookup('file', '../plugins/inventory/now.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
 
     - template:
-        src: ./templates/inventory.md.j2
+        src: ./templates/docs.md.j2
         dest: ./inventory.md
+
+    - set_fact:
+        docs: "{{ lookup('file', '../plugins/modules/snow_record.py') | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml}}"
+        examples: "{{ lookup('file', '../plugins/modules/snow_record.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
+
+    - template:
+        src: ./templates/docs.md.j2
+        dest: ./snow_record.md
+
+    - set_fact:
+        docs: "{{ lookup('file', '../plugins/modules/snow_record_find.py') | regex_search(\"(?<=DOCUMENTATION\\s=\\s''')((.|\\n)*?)(?=''')\") | from_yaml}}"
+        examples: "{{ lookup('file', '../plugins/modules/snow_record_find.py') | regex_search(\"(?<=EXAMPLES\\s=\\s''')((.|\\n)*?)(?=''')\") }}"
+
+    - template:
+        src: ./templates/docs.md.j2
+        dest: ./snow_record_find.md

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -1,0 +1,161 @@
+servicenow.servicenow.now - ServiceNow Inventory Plugin
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+- ServiceNow Inventory plugin
+
+## Requirements
+- requests
+- netaddr
+
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+<tr>
+<td><b>username</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td></td>
+<td><b>env:</b><br>
+-   name: SN_USERNAME
+</td>
+<td> The ServiceNow user acount, it should have rights to read cmdb_ci_server (default), or table specified by SN_TABLE</td>
+</tr>
+<tr>
+<td><b>plugin</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td><b>Choices:</b><br>
+- servicenow.servicenow.now
+</td>
+<td></td>
+<td> The name of the ServiceNow Inventory Plugin, this should always be 'servicenow.servicenow.now'.</td>
+</tr>
+<tr>
+<td><b>fields</b></br>
+</td>
+<td><b>Default:</b><br> 
+ip_address,fqdn,host_name,sys_class_name,name</td>
+<td></td>
+<td> Comma seperated string providing additional table columns to add as host vars to each inventory host.</td>
+</tr>
+<tr>
+<td><b>instance</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td></td>
+<td><b>env:</b><br>
+-   name: SN_INSTANCE
+</td>
+<td> The ServiceNow instance URI. The URI should be the fully-qualified domain name, e.g. 'your-instance.servicenow.com'.</td>
+</tr>
+<tr>
+<td><b>filter_results</b></br>
+</td>
+<td><b>Default:</b><br> 
+</td>
+<td></td>
+<td> Filter results with sysparm_query encoded query string syntax. Complete list of operators available for filters and queries.</td>
+</tr>
+<tr>
+<td><b>proxy</b></br>
+</td>
+<td><b>Default:</b><br> 
+</td>
+<td></td>
+<td> Proxy server to use for requests to ServiceNow.</td>
+</tr>
+<tr>
+<td><b>enhanced</b></br>
+</td>
+<td><b>Default:</b><br> 
+False</td>
+<td></td>
+<td> enable enhanced inventory which provides relationship information from CMDB. Requires installation of Update Set.</td>
+</tr>
+<tr>
+<td><b>selection_order</b></br>
+</td>
+<td><b>Default:</b><br> 
+ip_address,fqdn,host_name,name</td>
+<td></td>
+<td> Comma seperated string providing ability to define selection preference order.</td>
+</tr>
+<tr>
+<td><b>table</b></br>
+</td>
+<td><b>Default:</b><br> 
+cmdb_ci_server</td>
+<td></td>
+<td> The ServiceNow table to query</td>
+</tr>
+<tr>
+<td><b>enhanced_groups</b></br>
+</td>
+<td><b>Default:</b><br> 
+True</td>
+<td></td>
+<td> enable enhanced groups from CMDB relationships. Only used if enhanced is enabled.</td>
+</tr>
+<tr>
+<td><b>password</b></br>
+</td>
+<td></td>
+<td><b>env:</b><br>
+-   name: SN_PASSWORD
+</td>
+<td> The ServiceNow instance user password.</td>
+</tr>
+</table>
+
+## Examples
+```
+
+plugin: servicenow.servicenow.now
+instance: demo.service-now.com
+username: admin
+password: password
+keyed_groups:
+  - key: sn_sys_class_name | lower
+    prefix: ''
+    separator: ''
+
+plugin: servicenow.servicenow.now
+instance: demo.service-now.com
+username: admin
+password: password
+fields: [name,host_name,fqdn,ip_address,sys_class_name, install_status, classification,vendor]
+keyed_groups:
+  - key: sn_classification | lower
+    prefix: 'env'
+  - key: sn_vendor | lower
+    prefix: ''
+    separator: ''
+  - key: sn_sys_class_name | lower
+    prefix: ''
+    separator: ''
+  - key: sn_install_status | lower
+    prefix: 'status'
+
+plugin: servicenow.servicenow.now
+instance: demo.service-now.com
+username: admin
+password: password
+fields:
+  - name
+  - sys_tags
+compose:
+  sn_tags: sn_sys_tags.replace(" ", "").split(',')
+  ansible_host: sn_ip_address
+keyed_groups:
+  - key: sn_tags | lower
+    prefix: 'tag'
+
+```

--- a/docs/snow_record.md
+++ b/docs/snow_record.md
@@ -1,0 +1,156 @@
+snow_record - Manage records in ServiceNow
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+- Creates, deletes and updates a single record in ServiceNow.
+
+## Requirements
+- python pysnow (pysnow)
+
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+<tr>
+<td><b>number</b></br>
+</td>
+<td></td>
+<td></td>
+<td> [u'Record number to update.', u'Required for C(state:absent).']</td>
+</tr>
+<tr>
+<td><b>state</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td><b>Choices:</b><br>
+- present
+- absent
+</td>
+<td></td>
+<td> [u'If C(present) is supplied with a C(number) argument, the module will attempt to update the record with the supplied data.', u'If no such record exists, a new one will be created.', u'C(absent) will delete a record.']</td>
+</tr>
+<tr>
+<td><b>attachment</b></br>
+</td>
+<td></td>
+<td></td>
+<td> [u'Attach a file to the record.']</td>
+</tr>
+<tr>
+<td><b>table</b></br>
+</td>
+<td><b>Default:</b><br> 
+incident</td>
+<td></td>
+<td> [u'Table to query for records.']</td>
+</tr>
+<tr>
+<td><b>lookup_field</b></br>
+</td>
+<td><b>Default:</b><br> 
+number</td>
+<td></td>
+<td> [u'Changes the field that C(number) uses to find records.']</td>
+</tr>
+<tr>
+<td><b>data</b></br>
+</td>
+<td></td>
+<td></td>
+<td> [u'key, value pairs of data to load into the record. See Examples.', u'Required for C(state:present).']</td>
+</tr>
+</table>
+
+## Examples
+```
+
+- name: Grab a user record
+  snow_record:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    state: present
+    number: 62826bf03710200044e0bfc8bcbe5df1
+    table: sys_user
+    lookup_field: sys_id
+
+- name: Grab a user record using OAuth
+  snow_record:
+    username: ansible_test
+    password: my_password
+    client_id: "1234567890abcdef1234567890abcdef"
+    client_secret: "Password1!"
+    instance: dev99999
+    state: present
+    number: 62826bf03710200044e0bfc8bcbe5df1
+    table: sys_user
+    lookup_field: sys_id
+
+- name: Create an incident
+  snow_record:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    state: present
+    data:
+      short_description: "This is a test incident opened by Ansible"
+      severity: 3
+      priority: 2
+  register: new_incident
+
+- name: Create an incident using host instead of instance
+  snow_record:
+    username: ansible_test
+    password: my_password
+    host: dev99999.mycustom.domain.com
+    state: present
+    data:
+      short_description: "This is a test incident opened by Ansible"
+      priority: 2
+
+- name: Delete the record we just made
+  snow_record:
+    username: admin
+    password: xxxxxxx
+    instance: dev99999
+    state: absent
+    number: "{{new_incident['record']['number']}}"
+
+- name: Delete a non-existant record
+  snow_record:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    state: absent
+    number: 9872354
+  failed_when: false
+
+- name: Update an incident
+  snow_record:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    state: present
+    number: INC0000055
+    data:
+      work_notes : "Been working all day on this thing."
+
+- name: Attach a file to an incident
+  snow_record:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    state: present
+    number: INC0000055
+    attachment: README.md
+  tags: attach
+
+```

--- a/docs/snow_record_find.md
+++ b/docs/snow_record_find.md
@@ -1,0 +1,131 @@
+snow_record_find - Search for multiple records from ServiceNow
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+- Gets multiple records from a specified table from ServiceNow based on a query dictionary.
+
+## Requirements
+- python pysnow (pysnow)
+
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+<tr>
+<td><b>table</b></br>
+</td>
+<td><b>Default:</b><br> 
+incident</td>
+<td></td>
+<td> [u'Table to query for records.']</td>
+</tr>
+<tr>
+<td><b>max_records</b></br>
+</td>
+<td><b>Default:</b><br> 
+20</td>
+<td></td>
+<td> [u'Maximum number of records to return.']</td>
+</tr>
+<tr>
+<td><b>return_fields</b></br>
+</td>
+<td></td>
+<td></td>
+<td> [u'Fields of the record to return in the json.', u'By default, all fields will be returned.']</td>
+</tr>
+<tr>
+<td><b>order_by</b></br>
+</td>
+<td><b>Default:</b><br> 
+-created_on</td>
+<td></td>
+<td> [u'Field to sort the results on.', u'Can prefix with "-" or "+" to change descending or ascending sort order.']</td>
+</tr>
+<tr>
+<td><b>query</b></br>
+<p style="color:red;font-size:75%">required</p></td>
+<td></td>
+<td></td>
+<td> [u'Dict to query for records.']</td>
+</tr>
+</table>
+
+## Examples
+```
+
+- name: Search for incident assigned to group, return specific fields
+  snow_record_find:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    table: incident
+    query:
+      assignment_group: d625dccec0a8016700a222a0f7900d06
+    return_fields:
+      - number
+      - opened_at
+
+- name: Search for incident using host instead of instance
+  snow_record_find:
+    username: ansible_test
+    password: my_password
+    host: dev99999.mycustom.domain.com
+    table: incident
+    query:
+      assignment_group: d625dccec0a8016700a222a0f7900d06
+    return_fields:
+      - number
+      - opened_at
+
+- name: Using OAuth, search for incident assigned to group, return specific fields
+  snow_record_find:
+    username: ansible_test
+    password: my_password
+    client_id: "1234567890abcdef1234567890abcdef"
+    client_secret: "Password1!"
+    instance: dev99999
+    table: incident
+    query:
+      assignment_group: d625dccec0a8016700a222a0f7900d06
+    return_fields:
+      - number
+      - opened_at
+
+- name: Find open standard changes with my template
+  snow_record_find:
+    username: ansible_test
+    password: my_password
+    instance: dev99999
+    table: change_request
+    query:
+      AND:
+        equals:
+          active: "True"
+          type: "standard"
+          u_change_stage: "80"
+        contains:
+          u_template: "MY-Template"
+    return_fields:
+      - sys_id
+      - number
+      - sys_created_on
+      - sys_updated_on
+      - u_template
+      - active
+      - type
+      - u_change_stage
+      - sys_created_by
+      - description
+      - short_description
+
+```

--- a/docs/templates/docs.md.j2
+++ b/docs/templates/docs.md.j2
@@ -1,4 +1,4 @@
-{{ docs.name }} - {{ docs.short_description }}
+{% if docs.name is defined %}{{ docs.name }}{% else %}{{ docs.module }}{% endif %} - {{ docs.short_description }}
 ====================================
 - [Synopsis](Synopsis)
 - [Requirements](Requirements)

--- a/docs/templates/inventory.md.j2
+++ b/docs/templates/inventory.md.j2
@@ -1,0 +1,38 @@
+{{ docs.name }} - {{ docs.short_description }}
+====================================
+- [Synopsis](Synopsis)
+- [Requirements](Requirements)
+- [Parameters](Parameters)
+- [Examples](Examples)
+
+## Synopsis
+{{ docs.description | to_nice_yaml}}
+## Requirements
+{{ docs.requirements | default('') | to_nice_yaml }}
+## Parameters
+
+<table>
+<tr>
+<th> Parameter </th>
+<th> Choices/Defaults </th>
+<th> Configuration </th>
+<th> Comments </th>
+</tr>
+{% for option in docs.options %}
+<tr>
+<td><b>{{ option }}</b></br>
+{% if docs.options[option]['required'] is defined and docs.options[option]['required'] %}<p style="color:red;font-size:75%">required</p>{% endif %}</td>
+<td>{% if docs.options[option]['choices'] is defined %}<b>Choices:</b><br>
+{{ docs.options[option]['choices'] | to_nice_yaml }}{% endif %}{% if docs.options[option]['default'] is defined %}<b>Default:</b><br> 
+{{ docs.options[option]['default'] }}{% endif %}</td>
+<td>{% if docs.options[option]['env'] is defined %}<b>env:</b><br>
+{{ docs.options[option]['env'] | to_nice_yaml }}{% endif %}</td>
+<td> {{ docs.options[option]['description'] }}</td>
+</tr>
+{% endfor %}
+</table>
+
+## Examples
+```
+{{ examples }}
+```

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -3,7 +3,7 @@ import netaddr
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
 __metaclass__ = type
-DOCUMENTATION = r'''
+DOCUMENTATION = '''
     name: servicenow.servicenow.now
     plugin_type: inventory
     author:
@@ -16,6 +16,9 @@ DOCUMENTATION = r'''
     extends_documentation_fragment:
         - constructed
         - inventory_cache
+    requirements:
+        - requests
+        - netaddr
     options:
         plugin:
             description: The name of the ServiceNow Inventory Plugin, this should always be 'servicenow.servicenow.now'.
@@ -70,7 +73,7 @@ DOCUMENTATION = r'''
 
 '''
 
-EXAMPLES = r'''
+EXAMPLES = '''
 plugin: servicenow.servicenow.now
 instance: demo.service-now.com
 username: admin


### PR DESCRIPTION
This PR adds a dedicated docs page, formatted like standard Ansible documentation, for the inventory plugin and modules. This markdown file is generated by a jinja template and docs can be rebuilt using `docs/create_docs.yml` playbook.