### PR TITLE
Fix hostname transformation

### DIFF
--- a/changelogs/fragments/22_hostnames.yml
+++ b/changelogs/fragments/22_hostnames.yml
@@ -1,2 +1,2 @@
-bugfix:
+bugfixes:
 - fix inventory plugin transforming hostnames unnecessarily 

--- a/changelogs/fragments/22_hostnames.yml
+++ b/changelogs/fragments/22_hostnames.yml
@@ -1,0 +1,2 @@
+bugfix:
+- fix inventory plugin transforming hostnames unnecessarily 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, division, print_function
-import netaddr
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
 __metaclass__ = type
@@ -18,7 +17,6 @@ DOCUMENTATION = '''
         - inventory_cache
     requirements:
         - requests
-        - netaddr
     options:
         plugin:
             description: The name of the ServiceNow Inventory Plugin, this should always be 'servicenow.servicenow.now'.
@@ -265,10 +263,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 continue
 
             # add host to inventory
-            if netaddr.valid_ipv4(target) or netaddr.valid_ipv6(target):
-                host_name = self.inventory.add_host(target)
-            else:
-                host_name = self.inventory.add_host(to_safe_group_name(target))
+            host_name = self.inventory.add_host(target))
 
             # set variables for host
             for k in record.keys():

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -263,7 +263,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 continue
 
             # add host to inventory
-            host_name = self.inventory.add_host(target))
+            host_name = self.inventory.add_host(target)
 
             # set variables for host
             for k in record.keys():


### PR DESCRIPTION
This resolves issue #22 where the inventory would transform hostnames and group names. Hostnames should not be transformed.