### PR TITLE
update filter_results documentation, add  example usage

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -71,7 +71,7 @@ ip_address,fqdn,host_name,sys_class_name,name</td>
 <td><b>Default:</b><br> 
 </td>
 <td></td>
-<td> Filter results with sysparm_query encoded query string syntax. Complete list of operators available for filters and queries. </td>
+<td> Filter results with sysparm_query encoded query string syntax. Complete list of operators available for filters and queries found <a href="https://docs.servicenow.com/search?q=Available+Filters+Queries">here</a>. </td>
 </tr>
 <tr>
 <td><b>proxy</b></br>
@@ -125,8 +125,8 @@ True</td>
 </table>
 
 ## Examples
-```
-
+### Simple Inventory Plugin example
+```yaml
 plugin: servicenow.servicenow.now
 instance: dev89007
 username: admin
@@ -135,7 +135,10 @@ keyed_groups:
   - key: sn_sys_class_name | lower
     prefix: ''
     separator: ''
+```
 
+### Using Keyed Groups
+```yaml
 plugin: servicenow.servicenow.now
 host: servicenow.mydomain.com
 username: admin
@@ -152,7 +155,10 @@ keyed_groups:
     separator: ''
   - key: sn_install_status | lower
     prefix: 'status'
+```
 
+### Compose hostvars
+```yaml
 plugin: servicenow.servicenow.now
 instance: dev89007
 username: admin
@@ -166,5 +172,19 @@ compose:
 keyed_groups:
   - key: sn_tags | lower
     prefix: 'tag'
+```
 
+### Using table, selection_order, filter_results
+```yaml
+plugin: servicenow.servicenow.now
+instance: dev89007
+username: admin
+password: password
+table: cmdb_ci_netgear
+selection_order: fqdn
+fields: [name,host_name,fqdn,ip_address,sys_class_name,operational_status]
+filter_results: operational_status=1^fqdnISNOTEMPTY^manufacturerSTARTSWITHCisco
+keyed_groups:
+  - key: sn_operational_status | lower
+    prefix: 'op_status'
 ```

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -73,7 +73,9 @@ DOCUMENTATION = r'''
             type: list
             default: 'ip_address,fqdn,host_name,name'
         filter_results:
-            description: Filter results with sysparm_query encoded query string syntax. Complete list of operators available for filters and queries.
+            description:
+             - Filter results with sysparm_query encoded query string syntax.
+             - Complete list of operators available for filters and queries found here -> https://docs.servicenow.com/search?q=Available+Filters+Queries
             type: string
             default: ''
         proxy:
@@ -136,6 +138,19 @@ compose:
 keyed_groups:
   - key: sn_tags | lower
     prefix: 'tag'
+
+# Using table, selection_order, filter_results
+plugin: servicenow.servicenow.now
+instance: dev89007
+username: admin
+password: password
+table: cmdb_ci_netgear
+selection_order: fqdn
+fields: [name,host_name,fqdn,ip_address,sys_class_name,operational_status]
+filter_results: operational_status=1^fqdnISNOTEMPTY^manufacturerSTARTSWITHCisco
+keyed_groups:
+  - key: sn_operational_status | lower
+    prefix: 'op_status'
 '''
 
 import netaddr


### PR DESCRIPTION
Provide users with add'l documentation for using `filter_results` and finding the filter and query operators available from ServiceNow docs.  Example added.

Also, spruce up inventory.md with titles for the examples that match the DOCUMENTATION section of now.py