### PR TITLE
add support for host vars from fields in related tables

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -166,5 +166,19 @@ compose:
 keyed_groups:
   - key: sn_tags | lower
     prefix: 'tag'
+```
 
+### Use related table field
+```yaml
+plugin: servicenow.servicenow.now
+instance: dev89007
+username: admin
+password: password
+table: cmdb_ci_netgear
+selection_order: fqdn
+fields: [name,host_name,fqdn,model_id.model_number]
+filter_results: operational_status=1^fqdnISNOTEMPTY^manufacturerSTARTSWITHCisco
+keyed_groups:
+  - key: sn_model_id_model_number | lower
+    prefix: 'model'
 ```

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -139,6 +139,19 @@ compose:
 keyed_groups:
   - key: sn_tags | lower
     prefix: 'tag'
+
+# Use related table field
+plugin: servicenow.servicenow.now
+instance: dev89007
+username: admin
+password: password
+table: cmdb_ci_netgear
+selection_order: fqdn
+fields: [name,host_name,fqdn,model_id.model_number]
+filter_results: operational_status=1^fqdnISNOTEMPTY^manufacturerSTARTSWITHCisco
+keyed_groups:
+  - key: sn_model_id_model_number | lower
+    prefix: 'model'
 '''
 
 import netaddr

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -65,7 +65,10 @@ DOCUMENTATION = r'''
             type: string
             default: cmdb_ci_server
         fields:
-            description: Comma seperated string providing additional table columns to add as host vars to each inventory host.
+            description:
+            - Comma seperated string providing additional table columns to add as host vars to each inventory host.
+            - Related table fields are valid.  Usual period separator is changed to underscore.
+            - e.g. sn_model_id.model_name -> sn_model_id_model_name
             type: list
             default: 'ip_address,fqdn,host_name,sys_class_name,name'
         selection_order:
@@ -280,7 +283,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
             # set variables for host
             for k in record.keys():
-                self.inventory.set_variable(host_name, 'sn_%s' % k, record[k])
+                k2 = k.replace('.', '_')
+                self.inventory.set_variable(host_name, 'sn_%s' % k2, record[k])
 
             # add relationship based groups
             if enhanced and enhanced_groups:


### PR DESCRIPTION
example `now.yml`:
```yaml
plugin: servicenow.servicenow.now
instance: dev89007
username: admin
password: password
table: cmdb_ci_netgear
selection_order: fqdn
fields: [name,fqdn,model_id.model_number]
filter_results: operational_status=1^fqdnISNOTEMPTY^manufacturerSTARTSWITHCisco
keyed_groups:
  - key: sn_model_id_model_number | lower
    prefix: 'model'
```

produces host vars
```json
{
    "sn_fqdn": "my_switch.acme.com",
    "sn_model_id_model_number": "N9K-C93108TC-EX",
    "sn_name": "my_switch"
}
```

and group (`ansible-inventory -i now.yml --graph`)
```
@all:
|--@model_n9k_c93108tc_ex:
|  |--my_switch.acme.com
```