### PR TITLE
Add SN_FILTER_RESULTS  env settings.

### DIFF
--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -169,8 +169,6 @@ try:
 except ImportError:
     HAS_REQUESTS = False
 
-import os
-
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
 
@@ -265,9 +263,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         selection = self.get_option('selection_order')
         fields = self.get_option('fields')
         table = self.get_option('table')
-        filter_results = os.environ.get('SN_FILTER_RESULTS')
-        if not filter_results:
-            filter_results = self.get_option('filter_results')
+        filter_results = self.get_option('filter_results')
 
         options = "?sysparm_exclude_reference_link=true&sysparm_display_value=true"
 

--- a/plugins/inventory/now.py
+++ b/plugins/inventory/now.py
@@ -80,6 +80,8 @@ DOCUMENTATION = r'''
             description: Filter results with sysparm_query encoded query string syntax. Complete list of operators available for filters and queries.
             type: string
             default: ''
+            env:
+              - name: SN_FILTER_RESULTS
         proxy:
             description: Proxy server to use for requests to ServiceNow.
             type: string
@@ -166,6 +168,8 @@ try:
     HAS_REQUESTS = True
 except ImportError:
     HAS_REQUESTS = False
+
+import os
 
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable, to_safe_group_name
@@ -261,7 +265,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         selection = self.get_option('selection_order')
         fields = self.get_option('fields')
         table = self.get_option('table')
-        filter_results = self.get_option('filter_results')
+        filter_results = os.environ.get('SN_FILTER_RESULTS')
+        if not filter_results:
+            filter_results = self.get_option('filter_results')
 
         options = "?sysparm_exclude_reference_link=true&sysparm_display_value=true"
 


### PR DESCRIPTION
I have to create many dynamic inventories in AWX/Tower, each with a different filter.
This feature would make it much more easy to automate creation of such inventories via e.g. the ansible.tower.tower_inventory_source module.
We would need only one .yml -file in the project and can configure filters on each inventory_source, via the "env" -settings or a special credential_type using env.

would it be possible to pull this in?

BR 
Hampus